### PR TITLE
Expanding configuration settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3615,8 +3615,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3640,15 +3639,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3665,22 +3662,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3811,8 +3805,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3826,7 +3819,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3843,7 +3835,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3852,15 +3843,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3881,7 +3870,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3970,8 +3958,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3985,7 +3972,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4081,8 +4067,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4124,7 +4109,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4146,7 +4130,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4195,15 +4178,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6222,7 +6203,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -7206,8 +7186,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",

--- a/packages/ossus-components/src/blog/Sidebar.js
+++ b/packages/ossus-components/src/blog/Sidebar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { withConfig } from 'ossus';
 
@@ -14,12 +15,16 @@ function BlogSidebar({ config, title, limit }) {
   }));
 
   return (
-    <TocSection
-      title={title}
-      links={blogs}
-    />
+    <BlogSideBarContainer>
+      <TocSection title={title} links={blogs} />
+    </BlogSideBarContainer>
   );
 }
+
+const BlogSideBarContainer = styled('div')`
+  width: ${p => p.theme.size.width.blogSidebar + p.theme.size.unit};
+  max-width: ${p => p.theme.size.width.blogSidebar + p.theme.size.unit};
+`;
 
 BlogSidebar.propTypes = {
   config: PropTypes.shape({
@@ -27,12 +32,12 @@ BlogSidebar.propTypes = {
     toc: PropTypes.object
   }).isRequired,
   title: PropTypes.string,
-  limit: PropTypes.number,
+  limit: PropTypes.number
 };
 
 BlogSidebar.defaultProps = {
   title: 'Recent Posts',
-  limit: 10,
+  limit: 10
 };
 
 export default withConfig(BlogSidebar);

--- a/packages/ossus-components/src/components/BreadCrumbs.js
+++ b/packages/ossus-components/src/components/BreadCrumbs.js
@@ -122,8 +122,7 @@ const BreadCrumbsContainer = styled('div')`
   width: ${props => props.theme.size.width.page + props.theme.size.unit};
 
   .feather {
-    height: ${p => p.theme.breadcrumbs.font.size};
-    font-size: ${p => p.theme.breadcrumbs.font.size};
+    height: ${p => p.theme.breadcrumbs.divider.height};
     color: ${p => p.theme.breadcrumbs.color.fg};
   }
 

--- a/packages/ossus-components/src/components/BreadCrumbs.js
+++ b/packages/ossus-components/src/components/BreadCrumbs.js
@@ -98,7 +98,7 @@ const OuterContainer = styled('div')`
   z-index: 99;
   top: 0;
 
-  border-bottom: 1px solid ${p => p.theme.color.grey};
+  border-bottom: 1px solid ${p => p.theme.breadcrumbs.color.border};
   background-color: ${p => p.theme.breadcrumbs.color.bg};
   position: ${p => p.theme.header.sticky ? 'fixed' : 'static'};
   margin-top: calc(${props => {

--- a/packages/ossus-components/src/components/Button.js
+++ b/packages/ossus-components/src/components/Button.js
@@ -11,19 +11,21 @@ const Button = styled('button')`
   margin: ${p => p.margin || '0em'};
   width: ${p => p.width || 'auto'};
   height: ${p => p.height || 'auto'};
+  font-size: ${p => p.fontSize || p.theme.button.font.size};
 
-  color: ${p => p.theme.color.primary};
-  background-color: ${p => p.theme.color.bg};
-  border: 1.5px solid ${p => p.theme.color.primary};
-  border-radius: ${p => p.theme.size.radius + p.theme.size.unit};
-  font-family: ${p => p.theme.font.family.body};
-  font-size: ${p => p.fontSize || p.theme.font.size.body + p.theme.font.size.unit};
+  color: ${p => p.theme.button.color.fg};
+  background-color: ${p => p.theme.button.color.bg};
+  border:${p => `${p.theme.button.borderWidth} solid ${p.theme.button.color.border}`};
+  border-radius: ${p => p.theme.button.borderRadius};
+  font-family: ${p => p.theme.button.font.family};
+  font-weight: ${p => p.theme.button.font.weight};
 
   &:hover {
     cursor: pointer;
 
-    background-color: ${p => p.theme.color.primary};
-    color: ${p => p.theme.color.fgOnPrimary};
+    color: ${p => p.theme.button.color.fgHover};
+    background-color: ${p => p.theme.button.color.bgHover};
+    border:${p => `${p.theme.button.borderWidth} solid ${p.theme.button.color.borderHover}`};
   }
 `;
 

--- a/packages/ossus-components/src/components/FrontMatter.js
+++ b/packages/ossus-components/src/components/FrontMatter.js
@@ -34,7 +34,7 @@ function FrontMatter({ frontMatter, options }) {
         {
           opts.readTime && (
             <span className='meta-data'>
-              <Feather icon='clock' width={16} className='icon' />
+              <Feather icon='clock' width={16} height={16} className='icon' />
               {frontMatter.readTime || 0} minute read
             </span>
           )
@@ -78,6 +78,8 @@ const MetaData = styled('div')`
     display: flex;
     align-items: center;
     margin-right: 1em;
+
+    font-size: ${p => p.theme.type.frontmatter.font.size};
 
     .icon {
       margin-right: 5px;

--- a/packages/ossus-components/src/components/Layout.js
+++ b/packages/ossus-components/src/components/Layout.js
@@ -21,10 +21,11 @@ function Layout({ config, toc, children }) {
     <>
       <Global styles={css`
           * {
-              box-sizing: border-box;
+            box-sizing: border-box;
           }
           body {
-              margin: 0px;
+            margin: 0px;
+            background-color: ${t.color.bg};
           }
         `}
       />

--- a/packages/ossus-components/src/components/MarkdownComponents.js
+++ b/packages/ossus-components/src/components/MarkdownComponents.js
@@ -7,10 +7,12 @@ const A = styled('a')`
   font-size: ${p => p.theme.type.a.font.size};
   font-family: ${p => p.theme.type.a.font.family};
   font-weight: ${p => p.theme.type.a.font.weight};
+  line-height: ${p => p.theme.type.p.font.lineHeight};
+
   &:hover {
-      cursor: pointer;
-      text-decoration: underline;
-      color: ${p => lighten(0.1, p.theme.type.a.color)};
+    cursor: pointer;
+    text-decoration: underline;
+    color: ${p => lighten(0.1, p.theme.type.a.color)};
   }
 `;
 
@@ -19,15 +21,15 @@ const P = styled('p')`
   font-size: ${p => p.theme.type.p.font.size};
   font-family: ${p => p.theme.type.p.font.family};
   font-weight: ${p => p.theme.type.p.font.weight};
-  line-height: 1.5;
+  line-height: ${p => p.theme.type.p.font.lineHeight};
   padding: .25em 0em;
 
   code {
-      background-color: ${p => p.theme.code.color.inlineBg};
-      font-family: ${p => p.theme.code.font.family};
-      font-size: ${p => p.theme.code.font.size};
-      border-radius: 2px;
-      padding: 3px;
+    background-color: ${p => p.theme.code.color.inlineBg};
+    font-family: ${p => p.theme.code.font.family};
+    font-size: ${p => p.theme.code.font.size};
+    border-radius: 2px;
+    padding: 3px;
   }
 `;
 

--- a/packages/ossus-components/src/components/Menu.js
+++ b/packages/ossus-components/src/components/Menu.js
@@ -33,7 +33,7 @@ function Menu({ menu, activeHeader }) {
               )
             }
           </List>
-        ) : (<List></List>)
+        ) : (<List empty></List>)
       }
     </div>
   );
@@ -45,65 +45,76 @@ Menu.propTypes = {
 };
 
 const List = styled('ul')`
-    max-width: ${props => props.theme.size.width.menu + props.theme.size.unit};
-    min-width: ${props => props.theme.size.width.menu + props.theme.size.unit};
-    list-style: none;
-    border-left: 2px solid ${props => props.theme.color.secondary};
-    position: sticky;
-    margin-top: 0px;
-    left: ${props => (props.theme.size.width.page - props.theme.size.width.menu) + props.theme.size.unit};
-    top: calc(${props => {
-    if (props.theme.header.sticky) return (props.theme.size.height.header + props.theme.size.height.breadcrumbs) + props.theme.size.unit;
+  list-style: none;
+  position: sticky;
+  margin-top: 0px;
+  padding-left: 15px;
+  max-height: 500px;
+  overflow: auto;
+
+  border-radius: ${p => p.theme.menu.borderRadius};
+  background-color: ${p => p.empty ? 'transparent' : p.theme.menu.color.bg};
+  max-width: ${p => p.theme.size.width.menu + p.theme.size.unit};
+  min-width: ${p => p.theme.size.width.menu + p.theme.size.unit};
+  left: ${p => (p.theme.size.width.page - p.theme.size.width.menu) + p.theme.size.unit};
+  top: calc(${p => {
+    if (p.theme.header.sticky) return (p.theme.size.height.header + p.theme.size.height.breadcrumbs) + p.theme.size.unit;
     return '0em';
   }} + 1em);
-    padding-left: 15px;
-    max-height: 500px;
-    overflow: auto;
 
-    @media (max-width: ${props => props.theme.size.width.page + props.theme.size.unit}) {
-        display: none;
-    }
+  ${p => {
+    return p.theme.menu.divider
+      ? `border-left: ${p.theme.menu.divider.width} solid ${p.theme.menu.color.divider};`
+      : '';
+  }}
 
-    li:first-of-type {
-        padding-top: 0px;
-    }
+  @media (max-width: ${p => p.theme.size.width.page + p.theme.size.unit}) {
+    display: none;
+  }
 
-    li:last-child {
-        padding-bottom: 0px;
-    }
+  li:first-of-type {
+    padding-top: 0px;
+  }
+
+  li:last-child {
+    padding-bottom: 0px;
+  }
 `;
 
 const ListItem = styled('li')`
-    font-size: .8rem;
-    font-family: ${props => props.theme.font.family.body};
-    font-weight: ${p => p.theme.font.weight.semibold};
-    padding: 5px 0px;
-    color: ${props => props.theme.color.fg};
-    padding-left: ${p => (p.depth - 2) * 15}px;
+  padding-left: ${p => (p.depth - 2) * 15}px;
+  padding: 5px 0px;
+
+  color: ${p => p.theme.menu.color.fg};
+  font-size: ${p => p.theme.menu.font.size};
+  font-family: ${p => p.theme.menu.font.family};
+  font-weight: ${p => p.theme.menu.font.weight};
+  
+  ${p => p.active ? `
+  color: ${p.theme.menu.color.fgActive};
+  ` : ''}
+
+  &:hover {
+    cursor: pointer;
+    color: ${p => p.theme.menu.color.fgHover};
+  }
+  
+  a {
+    text-decoration: none;
+    color: ${p => p.theme.menu.color.fg};
+    font-size: ${p => p.theme.menu.font.size};
+    font-family: ${p => p.theme.menu.font.family};
+    font-weight: ${p => p.theme.menu.font.weight};
+    
     ${p => p.active ? `
-    font-weight: ${p.theme.font.weight.bold};
-    color: ${p.theme.color.primary};
+    color: ${p.theme.menu.color.fgActive};
     ` : ''}
 
     &:hover {
-        cursor: pointer;
-        color: ${props => props.theme.color.primary};
-        font-weight: ${p => p.theme.font.weight.semibold};
+      cursor: pointer;
+      color: ${p => p.theme.menu.color.fgHover};
     }
-    
-    a {
-        text-decoration: none;
-        color: ${props => props.theme.color.fg};
-        ${p => p.active ? `
-        font-weight: ${p.theme.font.weight.bold};
-        color: ${p.theme.color.primary};
-        ` : ''}
-
-        &:hover {
-            color: ${props => props.theme.color.primary};
-            font-weight: 500;
-        }
-    }
+  }
 `;
 
 export default Menu;

--- a/packages/ossus-components/src/components/Menu.js
+++ b/packages/ossus-components/src/components/Menu.js
@@ -48,7 +48,7 @@ const List = styled('ul')`
   list-style: none;
   position: sticky;
   margin-top: 0px;
-  padding-left: 15px;
+  padding:${p => p.theme.menu.space.padding};
   max-height: 500px;
   overflow: auto;
 
@@ -82,17 +82,13 @@ const List = styled('ul')`
 `;
 
 const ListItem = styled('li')`
-  padding-left: ${p => (p.depth - 2) * 15}px;
   padding: 5px 0px;
+  padding-left: ${p => (p.depth - 2) * 15}px;
 
-  color: ${p => p.theme.menu.color.fg};
+  color: ${p => p.active ? p.theme.menu.color.fgActive : p.theme.menu.color.fg};
   font-size: ${p => p.theme.menu.font.size};
   font-family: ${p => p.theme.menu.font.family};
   font-weight: ${p => p.theme.menu.font.weight};
-  
-  ${p => p.active ? `
-  color: ${p.theme.menu.color.fgActive};
-  ` : ''}
 
   &:hover {
     cursor: pointer;
@@ -101,14 +97,11 @@ const ListItem = styled('li')`
   
   a {
     text-decoration: none;
-    color: ${p => p.theme.menu.color.fg};
+
+    color: ${p => p.active ? p.theme.menu.color.fgActive : p.theme.menu.color.fg};
     font-size: ${p => p.theme.menu.font.size};
     font-family: ${p => p.theme.menu.font.family};
     font-weight: ${p => p.theme.menu.font.weight};
-    
-    ${p => p.active ? `
-    color: ${p.theme.menu.color.fgActive};
-    ` : ''}
 
     &:hover {
       cursor: pointer;

--- a/packages/ossus-components/src/components/Paging.js
+++ b/packages/ossus-components/src/components/Paging.js
@@ -2,9 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Routes } from 'ossus';
+// Components
 import Feather from 'feathered';
+// Variables
+const dirs = ['left', 'right'];
 
-const Paging = ({ nextDoc, prevDoc, page }) => {
+const Paging = ({ nextDoc, prevDoc, page, buttonAs }) => {
+  const LinkComp = buttonAs || PageLink;
   return (
     <StyledPaging>
       {
@@ -15,12 +19,7 @@ const Paging = ({ nextDoc, prevDoc, page }) => {
               section: prevDoc.section,
               doc: prevDoc.doc
             }}>
-              <a>
-                <Feather icon='chevron-left' />
-                <span className='link-info'>
-                  {prevDoc.label}
-                </span>
-              </a>
+              <LinkComp dir={dirs[0]} label={prevDoc.label} />
             </Routes.Link>
           </div>
         ) : null
@@ -33,12 +32,7 @@ const Paging = ({ nextDoc, prevDoc, page }) => {
               section: nextDoc.section,
               doc: nextDoc.doc
             }}>
-              <a>
-                <span className='link-info'>
-                  {nextDoc.label}
-                </span>
-                <Feather icon='chevron-right' />
-              </a>
+              <LinkComp dir={dirs[1]} label={nextDoc.label} />
             </Routes.Link>
           </div>
         ) : null
@@ -60,6 +54,54 @@ Paging.propTypes = {
   }),
   page: PropTypes.string,
 };
+
+function PageLink({ dir, label, ...rest }) {
+  return (
+    <PageLinkStyled dir={dir} {...rest}>
+      {dir === dirs[0] && <Feather icon='chevron-left' />}
+      <span>{label}</span>
+      {dir === dirs[1] && <Feather icon='chevron-right' />}
+    </PageLinkStyled>
+  );
+}
+
+PageLink.propTypes = {
+  dir: PropTypes.oneOf(dirs),
+  label: PropTypes.string
+};
+
+const PageLinkStyled = styled('a')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-decoration: none;
+  padding: 1em;
+  height: 100%;
+
+  border-radius: ${p => p.theme.paging.borderRadius};
+  border: ${p => `${p.theme.paging.borderWidth} solid ${p.theme.paging.color.border}`};
+  background-color: ${p => p.theme.paging.color.bg};
+  color: ${p => p.theme.paging.color.fg};
+  font-size: ${p => p.theme.paging.font.size};
+  font-weight: ${p => p.theme.paging.font.weight};
+  font-family: ${p => p.theme.paging.font.family};
+  
+  transition: background-color .25s ease, color .2s ease;
+
+  ${p => {
+    if (p.dir === dirs[0]) {
+      return 'text-align: right;';
+    }
+    return '';
+  }}
+
+  &:hover {
+    cursor: pointer;
+    border: ${p => `${p.theme.paging.borderWidth} solid ${p.theme.paging.color.borderHover}`};
+    background-color: ${p => p.theme.paging.color.bgHover};
+    color: ${p => p.theme.paging.color.fgHover};
+  }
+`;
 
 const StyledPaging = styled('div')`
   padding-top: 2em;
@@ -88,40 +130,10 @@ const StyledPaging = styled('div')`
 
     &.left {
       margin: 0em 1em 0em 0em;
-      text-align: right;
     }
 
     &.right {
       margin: 0em 0em 0em 1em;
-    }
-
-    a {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      border: 1.5px solid #ccc;
-      border-radius: 4px;
-      padding: 1em;
-      text-decoration: none;
-      color: #888;
-      transition: background-color .25s ease, color .2s ease;
-      height: 100%;
-
-      .link-info {
-        font-weight: ${props => props.theme.font.weight.semibold};
-        font-family: ${props => props.theme.font.family.title};
-        color: ${props => props.theme.color.fg};
-      }
-
-      &:hover {
-        background-color: ${props => props.theme.color.primary};
-        color: ${props => props.theme.color.fgOnPrimary};
-        border: 1.5px solid ${props => props.theme.color.primary};
-
-        .link-info {
-          color: ${props => props.theme.color.fgOnPrimary};
-        }
-      }
     }
   }
 `;

--- a/packages/ossus-components/src/components/TOCSection.js
+++ b/packages/ossus-components/src/components/TOCSection.js
@@ -36,7 +36,7 @@ TocSection.propTypes = {
 
 const Section = styled('nav')`
   width: 100%;
-  
+
   background-color: ${p => p.theme.toc.color.bg};
 `;
 
@@ -68,25 +68,16 @@ const SectionItem = styled('li')`
     text-decoration: none;
     
     padding: ${p => p.theme.toc.item.space.padding};
-    color: ${p => p.theme.toc.item.color.fg};
+    color: ${p => p.highlight ? p.theme.toc.item.color.fgActive : p.theme.toc.item.color.fg};
     font-size: ${p => p.theme.toc.item.font.size};
     font-family: ${p => p.theme.toc.item.font.family};
     font-weight: ${p => p.theme.toc.item.font.weight};
-    background-color: ${p => p.theme.toc.item.color.bg};
+    background-color: ${p => p.highlight ? p.theme.toc.item.color.bgActive : p.theme.toc.item.color.bg};
 
     &:hover {
       cursor: pointer;
       color: ${p => p.theme.toc.item.color.fgHover};
     }
-
-    ${p => p.highlight ? `
-      color: ${p => p.theme.toc.item.color.fgActive};
-      background-color: ${p => p.theme.toc.item.color.bgActive};
-
-      &:hover {
-        color: ${p => p.theme.toc.item.color.fgActive};
-      }
-    `: ''}
   }
 `;
 

--- a/packages/ossus-components/src/components/TOCSection.js
+++ b/packages/ossus-components/src/components/TOCSection.js
@@ -35,19 +35,21 @@ TocSection.propTypes = {
 };
 
 const Section = styled('nav')`
-  width: ${p => p.theme.size.width.blogSidebar + p.theme.size.unit};
-  max-width: ${p => p.theme.size.width.blogSidebar + p.theme.size.unit};
+  width: 100%;
+  
+  background-color: ${p => p.theme.toc.color.bg};
 `;
 
 const SectionTitle = styled('h1')`
   width: 100%;
-  margin: 0;
-  font-size: 1.1rem;
-  padding: .25em 1em .25em 0em;
-
-  color: ${p => p.theme.color.primary};
-  font-family: ${p => p.theme.font.family.body};
-  font-weight: ${p => p.theme.font.weight.semibold};
+  
+  color: ${p => p.theme.toc.title.color.fg};
+  font-size: ${p => p.theme.toc.title.font.size};
+  font-family: ${p => p.theme.toc.title.font.family};
+  font-weight: ${p => p.theme.toc.title.font.weight};
+  background-color: ${p => p.theme.toc.title.color.bg};
+  margin: ${p => p.theme.toc.title.space.margin};
+  padding: ${p => p.theme.toc.title.space.padding};
 `;
 
 const SectionItems = styled('ul')`
@@ -59,30 +61,32 @@ const SectionItems = styled('ul')`
 
 const SectionItem = styled('li')`
   padding: 0em;
-  margin: .25em 0em;
+  margin: ${p => p.theme.toc.item.space.margin};
 
   a {
     display: block;
     text-decoration: none;
-    padding: .75em 1em;
-
-    color: ${p => p.theme.color.fg};
-    font-size: ${p => p.theme.font.size.body + p.theme.font.size.unit};
-    font-family: ${p => p.theme.font.family.body};
-    font-weight: ${p => p.theme.font.weight.regular};
+    
+    padding: ${p => p.theme.toc.item.space.padding};
+    color: ${p => p.theme.toc.item.color.fg};
+    font-size: ${p => p.theme.toc.item.font.size};
+    font-family: ${p => p.theme.toc.item.font.family};
+    font-weight: ${p => p.theme.toc.item.font.weight};
+    background-color: ${p => p.theme.toc.item.color.bg};
 
     &:hover {
-      color: ${p => p.theme.color.primary}
+      cursor: pointer;
+      color: ${p => p.theme.toc.item.color.fgHover};
     }
 
-    ${p => p.highlight && `
-      color: ${p.theme.color.fgOnPrimary};
-      background-color: ${p.theme.color.primary};
+    ${p => p.highlight ? `
+      color: ${p => p.theme.toc.item.color.fgActive};
+      background-color: ${p => p.theme.toc.item.color.bgActive};
 
       &:hover {
-        color: ${p.theme.color.fgOnPrimary};
+        color: ${p => p.theme.toc.item.color.fgActive};
       }
-    `}
+    `: ''}
   }
 `;
 

--- a/packages/ossus-components/src/defaultTheme.js
+++ b/packages/ossus-components/src/defaultTheme.js
@@ -66,7 +66,67 @@ function generateDefaultTheme(color, font) {
       spacing: '10px',
       color: {
         bg: color.bg,
-        fg: color.fg
+        fg: color.fg,
+        border: color.grey
+      },
+      font: {
+        size: font.size.body + font.size.unit,
+        family: font.family.body,
+        weight: font.weight.regular
+      },
+      divider: {
+        height: font.size.body + font.size.unit
+      }
+    },
+    toc: {
+      color: {
+        bg: color.bg,
+      },
+      title: {
+        space: {
+          margin: '0',
+          padding: '.25em 1em .25em 0em',
+        },
+        color: {
+          fg: color.fg,
+          bg: color.bg
+        },
+        font: {
+          size: '1rem',
+          family: font.family.body,
+          weight: font.weight.regular
+        }
+      },
+      item: {
+        space: {
+          margin: '.25em 0em',
+          padding: '.75em 1em',
+        },
+        color: {
+          bg: color.bg,
+          fg: color.fg,
+          fgHover: color.primary,
+          fgActive: color.fgOnPrimary,
+          bgActive: color.primary
+        },
+        font: {
+          size: font.size.body + font.size.unit,
+          family: font.family.body,
+          weight: font.weight.regular
+        }
+      }
+    },
+    menu: {
+      borderRadius: '0px',
+      divider: {
+        width: '2px'
+      },
+      color: {
+        bg: color.bg,
+        fg: color.fg,
+        fgHover: color.primary,
+        fgActive: color.primary,
+        divider: color.fg
       },
       font: {
         size: font.size.body + font.size.unit,

--- a/packages/ossus-components/src/defaultTheme.js
+++ b/packages/ossus-components/src/defaultTheme.js
@@ -118,6 +118,9 @@ function generateDefaultTheme(color, font) {
     },
     menu: {
       borderRadius: '0px',
+      space: {
+        padding: '0px 0px 0px 12px'
+      },
       divider: {
         width: '2px'
       },
@@ -127,6 +130,40 @@ function generateDefaultTheme(color, font) {
         fgHover: color.primary,
         fgActive: color.primary,
         divider: color.fg
+      },
+      font: {
+        size: font.size.body + font.size.unit,
+        family: font.family.body,
+        weight: font.weight.regular
+      }
+    },
+    button: {
+      borderRadius: '4px',
+      borderWidth: '1.5px',
+      color: {
+        bg: color.bg,
+        fg: color.primary,
+        border: color.primary,
+        bgHover: color.primary,
+        fgHover: color.fgOnPrimary,
+        borderHover: color.primary,
+      },
+      font: {
+        size: font.size.body + font.size.unit,
+        family: font.family.body,
+        weight: font.weight.regular
+      }
+    },
+    paging: {
+      borderRadius: '4px',
+      borderWidth: '1.5px',
+      color: {
+        bg: color.bg,
+        fg: color.primary,
+        border: color.grey,
+        bgHover: color.primary,
+        fgHover: color.fgOnPrimary,
+        borderHover: color.primary,
       },
       font: {
         size: font.size.body + font.size.unit,
@@ -157,7 +194,8 @@ function generateDefaultTheme(color, font) {
         font: {
           size: font.size.body + font.size.unit,
           family: font.family.body,
-          weight: font.weight.regular
+          weight: font.weight.regular,
+          lineHeight: '1.5'
         },
         color: color.primary,
       },
@@ -165,7 +203,8 @@ function generateDefaultTheme(color, font) {
         font: {
           size: font.size.body + font.size.unit,
           family: font.family.body,
-          weight: font.weight.regular
+          weight: font.weight.regular,
+          lineHeight: '1.5'
         },
         color: color.fg,
       },

--- a/packages/ossus-components/src/docs/TableOfContents.js
+++ b/packages/ossus-components/src/docs/TableOfContents.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'next/router';
 import styled from '@emotion/styled';
+import { withRouter } from 'next/router';
 
 import { tocUtil, withConfig } from 'ossus';
 
@@ -49,67 +49,24 @@ TableOfContents.propTypes = {
 };
 
 const TocContainer = styled('div')`
-  min-width: ${props => props.theme.size.width.toc}px;
-  max-width: ${props => props.theme.size.width.toc}px;
-  background-color: white;
+  left: 0px;
   position: sticky;
-  top: calc(${props => {
-    if (props.theme.header.sticky) return props.theme.size.height.header + props.theme.size.height.breadcrumbs + props.theme.size.unit;
+  margin-bottom: 1em;
+  background-color: white;
+
+  min-width: ${p => p.theme.size.width.toc + p.theme.size.unit};
+  max-width: ${p => p.theme.size.width.toc + p.theme.size.unit};
+
+  top: calc(${p => {
+    if (p.theme.header.sticky) return p.theme.size.height.header + p.theme.size.height.breadcrumbs + p.theme.size.unit;
     return '0em';
   }} + 1em);
-  left: 0px;
-  margin-bottom: 1em;
 
-  @media (max-width: 720px) {
+  @media (max-width: ${p => p.theme.size.responsive.mobile + p.theme.size.responsive.unit}) {
       position: static;
       min-width: 100%;
       max-width: 100%;
   }
 `;
-
-// const SectionTitle = styled('div')`
-//     width: 100%;
-//     color: ${props => props.theme.color.primary};
-//     font-family: ${props => props.theme.font.family.body};
-//     font-weight: ${props => props.theme.font.weight.semibold};
-//     font-size: 1.1rem;
-//     margin: 0;
-//     padding: .25em 1em .25em 0em;
-// `;
-
-// const SectionList = styled('ul')`
-//   margin: 0;
-//   list-style: none;
-//   width: 100%;
-//   padding-left: 0px;
-//   margin: .5em 0em .5em .2em;
-
-//   li {
-//     a {
-//       display: block;
-//       color: ${props => props.theme.type.p.color};
-//       font-family: ${props => props.theme.type.a.font.family};
-//       font-weight: ${props => props.theme.type.a.font.weight};
-//       font-size: .85rem;
-//       text-decoration: none;
-//       padding: .75em 1em;
-//       margin: .1em 0em;
-//       transform: translateX(-1px);
-
-//       &.highlight {
-//         color: ${props => props.theme.color.fgOnPrimary};
-//         background-color: ${props => props.theme.color.primary};
-
-//         &:hover {
-//           color: ${props => props.theme.color.fgOnPrimary};
-//         }
-//       }
-
-//       &:hover {
-//         color: ${props => props.theme.color.primary}
-//       }
-//     }
-//   }
-// `;
 
 export default withConfig(withRouter(TableOfContents));

--- a/packages/sample/config/config.js
+++ b/packages/sample/config/config.js
@@ -79,7 +79,7 @@ const site = {
 
 const theme = {
   color: {
-    primary: "#000"
+    primary: "#000",
   },
   size: {
     height: {

--- a/packages/sample/config/config.js
+++ b/packages/sample/config/config.js
@@ -1,92 +1,99 @@
 const site = {
-        name: 'Ossus',
-        tagline: 'Simple customizable documentation sites fast',
-        trademark: ( <span> &#x24B8; 2018. CDK Open Source </span>),
-            headerLinks: [{
-                    route: 'docs',
-                    params: {
-                        page: 'overview',
-                        section: 'getting-started',
-                        doc: 'installation'
-                    },
-                    label: 'Docs'
-                },
-                {
-                    route: 'docs',
-                    params: {
-                        page: 'api',
-                        section: 'intro',
-                        doc: 'basics'
-                    },
-                    label: 'API'
-                },
-                {
-                    href: 'https://github.com',
-                    label: 'Github'
-                }
-            ],
-            socialLinks: [{
-                route: 'https://github.com/ossus',
-                label: 'Github'
-            }],
-            footerLinks: [{
-                    title: 'Docs',
-                    links: [{
-                            route: 'docs',
-                            params: {
-                                page: 'overview',
-                                section: 'getting-started',
-                                doc: 'installation'
-                            },
-                            label: 'Getting Started'
-                        },
-                        {
-                            route: 'docs',
-                            params: {
-                                page: 'overview',
-                                section: 'getting-started',
-                                doc: 'basics'
-                            },
-                            label: 'Basics'
-                        },
-                        {
-                            route: 'docs',
-                            params: {
-                                page: 'overview',
-                                section: 'getting-started',
-                                doc: 'configuration'
-                            },
-                            label: 'Configuration'
-                        }
-                    ]
-                },
-                {
-                    title: 'Social',
-                    links: [{
-                        href: 'https://github.com/cdkOpensource',
-                        label: 'Github'
-                    }]
-                }
-            ]
+  name: "Ossus",
+  tagline: "Simple customizable documentation sites fast",
+  trademark: <span> &#x24B8; 2018. CDK Open Source </span>,
+  headerLinks: [
+    {
+      route: "docs",
+      params: {
+        page: "overview",
+        section: "getting-started",
+        doc: "installation"
+      },
+      label: "Docs"
+    },
+    {
+      route: "docs",
+      params: {
+        page: "api",
+        section: "intro",
+        doc: "basics"
+      },
+      label: "API"
+    },
+    {
+      href: "https://github.com",
+      label: "Github"
+    }
+  ],
+  socialLinks: [
+    {
+      route: "https://github.com/ossus",
+      label: "Github"
+    }
+  ],
+  footerLinks: [
+    {
+      title: "Docs",
+      links: [
+        {
+          route: "docs",
+          params: {
+            page: "overview",
+            section: "getting-started",
+            doc: "installation"
+          },
+          label: "Getting Started"
+        },
+        {
+          route: "docs",
+          params: {
+            page: "overview",
+            section: "getting-started",
+            doc: "basics"
+          },
+          label: "Basics"
+        },
+        {
+          route: "docs",
+          params: {
+            page: "overview",
+            section: "getting-started",
+            doc: "configuration"
+          },
+          label: "Configuration"
         }
-
-        const theme = {
-            color: {
-                primary: '#000'
-            },
-            size: {
-                height: {
-                    header: 100,
-                    headerMobile: 90,
-                    breadcrumbs: 50,
-                }
-            },
-            header: {
-                sticky: true
-            }
+      ]
+    },
+    {
+      title: "Social",
+      links: [
+        {
+          href: "https://github.com/cdkOpensource",
+          label: "Github"
         }
+      ]
+    }
+  ]
+};
 
-        export default {
-            site,
-            theme
-        };
+const theme = {
+  color: {
+    primary: "#000"
+  },
+  size: {
+    height: {
+      header: 100,
+      headerMobile: 90,
+      breadcrumbs: 50
+    }
+  },
+  header: {
+    sticky: true
+  },
+};
+
+export default {
+  site,
+  theme
+};


### PR DESCRIPTION
Working to expand the available configuration settings. This PR will add: 
- paragraph & a tag line height
- improved configuration for breadcrumbs
- improved configuration for table of contents including title and item sections
- improved menu configuration; allowing removal of border and padding options
- button specific configurations
- Paging specific configurations as well as plug-able `buttonAs` prop to define the component used in the pager
- Fixing a few spots where configuration was defined but not used properly